### PR TITLE
fix(Swapping): support swapping archetype by fixing a few bugs

### DIFF
--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Locales/en.json
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Locales/en.json
@@ -453,7 +453,7 @@
         },
         "13003": {
             "Name": "Sarah",
-            "Info": "Deploy: Swap a card for one of the same color.",
+            "Info": "Deploy: Swap a card for a different one of the same color.",
             "Flavor": "来陪小莎拉玩游戏吧！"
         },
         "13004": {
@@ -3203,7 +3203,7 @@
         },
         "130030": {
             "Name": "Sarah: Promoted",
-            "Info": "Deploy: Swap 3 cards for ones of the same color.",
+            "Info": "Deploy: Swap 3 cards for different ones of the same color.",
             "Flavor": "来陪小莎拉玩游戏吧！"
         },
         "130040": {

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Locales/en.json
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Locales/en.json
@@ -1793,7 +1793,7 @@
         },
         "43002": {
             "Name": "Ves",
-            "Info": "Deploy: Swap up to 2 cards.",
+            "Info": "Deploy: Swap up to 2 cards for two different cards from your deck.",
             "Flavor": "宁似帝王快活一天，强如乞丐苟活一世。"
         },
         "43003": {

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/StreamingFile/Locales/en.json
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/StreamingFile/Locales/en.json
@@ -1793,7 +1793,7 @@
         },
         "43002": {
             "Name": "Ves",
-            "Info": "Deploy: Swap up to 2 cards.",
+            "Info": "Deploy: Swap up to 2 cards for two different cards from your deck.",
             "Flavor": "宁似帝王快活一天，强如乞丐苟活一世。"
         },
         "43003": {

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/StreamingFile/Locales/en.json
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/StreamingFile/Locales/en.json
@@ -453,7 +453,7 @@
         },
         "13003": {
             "Name": "Sarah",
-            "Info": "Deploy: Swap a card for one of the same color.",
+            "Info": "Deploy: Swap a card for a different one of the same color.",
             "Flavor": "来陪小莎拉玩游戏吧！"
         },
         "13004": {
@@ -3188,7 +3188,7 @@
         },
         "130030": {
             "Name": "Sarah: Promoted",
-            "Info": "Deploy: Swap 3 cards for ones of the same color.",
+            "Info": "Deploy: Swap 3 cards for different ones of the same color.",
             "Flavor": "来陪小莎拉玩游戏吧！"
         },
         "130040": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
@@ -851,6 +851,13 @@ namespace Cynthia.Card
 
         public virtual async Task SwapWithDeck()
         {
+            if (!Card.Status.CardRow.IsInHand())
+            {
+                return;
+            }
+            
+            Card.Status.IsReveal = false;
+
             // put the card to the deck
             await Game.ShowCardMove(new CardLocation(RowPosition.MyDeck, Game.RNG.Next(0, Game.PlayersDeck[PlayerIndex].Count() + 1)), Card);
             await Game.SendEvent(new AfterCardSwap(Card));

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
@@ -849,6 +849,23 @@ namespace Cynthia.Card
             await GetDeckSwapCard(target);
         }
 
+        public virtual async Task SwapWithDeck()
+        {
+            // put the card to the deck
+            await Game.ShowCardMove(new CardLocation(RowPosition.MyDeck, Game.RNG.Next(0, Game.PlayersDeck[PlayerIndex].Count() + 1)), Card);
+            await Game.SendEvent(new AfterCardSwap(Card));
+
+            // try to select a card from the new deck (example card could have come out from the deck)
+            if (!Game.PlayersDeck[PlayerIndex].TryMessOne(out var swapDeckCard, Game.RNG))
+            {
+                return;
+            }
+
+            // pull the selected card from the deck
+            await Game.PlayerDrawCard(Card.PlayerIndex, filter: x => x == swapDeckCard);
+            await Game.SendEvent(new AfterDrawSwapCard(swapDeckCard));
+        }
+
         public virtual async Task GetDeckSwapCard(GameCard target)
         {
             await Game.PlayerDrawCard(Card.PlayerIndex, filter: x => x == target);

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/Ves.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/Ves.cs
@@ -1,7 +1,6 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Alsein.Extensions;
-using System.Collections.Generic;
 
 namespace Cynthia.Card
 {
@@ -20,17 +19,31 @@ namespace Cynthia.Card
             }
             var selectList = Game.PlayersHandCard[PlayerIndex].ToList();
             var handresult = await Game.GetSelectMenuCards(PlayerIndex, selectList, 2, "选择交换张牌", isCanOver: true);
-            int swapnum = handresult.ToList().Count();
+            int swapnum = handresult.Count();
             if (swapnum == 0)
             {
                 return 0;
             }
-            foreach (var card in handresult)
-            {
-                await card.Effect.Swap();
+
+            // pre-select swapnum cards from deck
+            if(!Game.PlayersDeck[PlayerIndex].TryMessN(out var cardsFromDeck, Game.RNG, swapnum)) {
+                return 0;
             }
-            await Game.PlayerDrawCard(Card.PlayerIndex, swapnum);
+
+            // swap cards based on the min cards between deck and swapnum
+            for (int i = 0; i < Math.Min(swapnum, cardsFromDeck.Count()); i++)
+            {
+                await handresult[i].Effect.Swap(cardsFromDeck.ElementAt(i));
+            }
+
             return 0;
+            
+            // foreach (var card in handresult)
+            // {
+            //     await card.Effect.Swap();
+            // }
+            // await Game.PlayerDrawCard(Card.PlayerIndex, swapnum);
+            // return 0;
 
 
 

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Copper/ElvenScout.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Copper/ElvenScout.cs
@@ -15,11 +15,15 @@ namespace Cynthia.Card
             {
                 return 0;
             }
-            if (!Game.PlayersDeck[PlayerIndex].TryMessOne(out var swapDeckCard, Game.RNG))
-            {
-                return 0;
-            }
-            await swapHandCard.Effect.Swap(swapDeckCard);
+            
+            // if (!Game.PlayersDeck[PlayerIndex].TryMessOne(out var swapDeckCard, Game.RNG))
+            // {
+            //     return 0;
+            // }
+            // await swapHandCard.Effect.Swap(swapDeckCard);
+
+            await swapHandCard.Effect.SwapWithDeck();
+
             return 0;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Copper/VriheddOfficer.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Copper/VriheddOfficer.cs
@@ -20,12 +20,15 @@ namespace Cynthia.Card
                 return 0;
             }
 
-            if (!Game.PlayersDeck[PlayerIndex].TryMessOne(out var swapDeckCard, Game.RNG))
-            {
-                return 0;
-            }
+            // if (!Game.PlayersDeck[PlayerIndex].TryMessOne(out var swapDeckCard, Game.RNG))
+            // {
+            //     return 0;
+            // }
 
-            await swapHandCard.Effect.Swap(swapDeckCard);
+            // await swapHandCard.Effect.Swap(swapDeckCard);
+
+            await swapHandCard.Effect.SwapWithDeck();
+
             await Card.Effect.Boost(swapHandCard.Status.Strength, Card);
             return 0;
         }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/Extensions/EnumerableExtensions.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/Extensions/EnumerableExtensions.cs
@@ -30,6 +30,11 @@ namespace Cynthia.Card
             result = items.Mess(rng).FirstOrDefault();
             return result == null ? false : true;
         }
+        public static bool TryMessN<T>(this IEnumerable<T> items, out IEnumerable<T> result, Random rng, int count)
+        {
+            result = items.Mess(rng).Take(count).DefaultIfEmpty();
+            return result == null ? false : true;
+        }
         public static string ToJson(this object obj)
         {
             return JsonConvert.SerializeObject(obj);

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -453,7 +453,7 @@
         },
         "13003": {
             "Name": "Sarah",
-            "Info": "Deploy: Swap a card for one of the same color.",
+            "Info": "Deploy: Swap a card for a different one of the same color.",
             "Flavor": "来陪小莎拉玩游戏吧！"
         },
         "13004": {
@@ -3203,7 +3203,7 @@
         },
         "130030": {
             "Name": "Sarah: Promoted",
-            "Info": "Deploy: Swap 3 cards for ones of the same color.",
+            "Info": "Deploy: Swap 3 cards for different ones of the same color.",
             "Flavor": "来陪小莎拉玩游戏吧！"
         },
         "130040": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Locales/en.json
@@ -1793,7 +1793,7 @@
         },
         "43002": {
             "Name": "Ves",
-            "Info": "Deploy: Swap up to 2 cards.",
+            "Info": "Deploy: Swap up to 2 cards for two different cards from your deck.",
             "Flavor": "宁似帝王快活一天，强如乞丐苟活一世。"
         },
         "43003": {


### PR DESCRIPTION
current implementation: a card in the deck is pre-selected from the deck before the swap happens

this introduces two bugs:
- the same card can never be drawn during the swap (which I think was not the case in old Gwent)
- card can't be swapped when current deck size is 0 (this was definitely possible in old Gwent)

new implementation:
- card is first put into the deck, and the post swap abilities are triggered
- now a card is selected at random from the new deck and drawn

this will help fix the bugs mentioned above

Currently I have called this new function only for Vrihedd Officer and Elven Scout card effects.
Let me know if this needs to be added to other cards as well

### To-Do
- [x] update ves code to include blacklisting
- [x] update ves description to include blacklisting