### PR TITLE
Expansion for the new season - Lore/Bug/QoL/EnDescription fixes

### DIFF
--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/StreamingFile/Locales/en.json
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/StreamingFile/Locales/en.json
@@ -2998,12 +2998,12 @@
         },
         "70045": {
             "Name": "Meve",
-            "Info": "Deploy: Boost a unit on your side of the board, in your hand and in your deck each by 4.\nCrew.",
+            "Info": "Deploy: Boost a unit on your side of the board, in your hand and in your deck each by 5.\nCrew.",
             "Flavor": ""
         },
         "70046": {
             "Name": "Svalblod Fanatic",
-            "Info": "On round end, deal 3 Damage to the Lowest enemy, then deal 3 Damage to self.",
+            "Info": "On turn end, deal 3 Damage to the Lowest enemy, then deal 3 Damage to self.",
             "Flavor": ""
         },
         "70050": {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
@@ -190,7 +190,7 @@ namespace Cynthia.Card
             });
             async Task sendEventTask()
             {
-                if (Card.Status.IsDoomed || (isNeedBanish && Card.Status.Strength <= 0 && Card.Status.Type == CardType.Unit))//如果是佚亡,放逐
+                if ((Card.Status.IsDoomed && isDead) || (isNeedBanish && Card.Status.Strength <= 0 && Card.Status.Type == CardType.Unit))//如果是佚亡,放逐
                 {
                     await Banish();
                     if (isNeedSentEvent && discardInfo.isDiscard && !deadposition.RowPosition.IsOnPlace())
@@ -672,7 +672,7 @@ namespace Cynthia.Card
             await Game.ShowSetCard(Card);
             await Game.SetPointInfo();
             //8888888888888888888888888888888888888888888888888888888888888888888888
-            //变为,应该触发对应事件<暂未定义,待补充>
+                await Game.SendEvent(new AfterCardTransform(Card, source));
             //8888888888888888888888888888888888888888888888888888888888888888888888
         }
         public virtual async Task Resurrect(CardLocation location, GameCard source)//复活

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Silver/IrisCompanions.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Silver/IrisCompanions.cs
@@ -21,7 +21,7 @@ namespace Cynthia.Card
             await Game.PlayerDrawCard(PlayerIndex);//抽卡
                                                    //---------------------------------------------------------------------------
                                                    //随机弃掉一张
-            await Game.PlayersHandCard[PlayerIndex].Mess(RNG).First().Effect.ToCemetery();
+            await Game.PlayersHandCard[PlayerIndex].Mess(RNG).First().Effect.Discard(Card);
             return 0;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Gold/LethoOfGulet.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Gold/LethoOfGulet.cs
@@ -9,14 +9,27 @@ namespace Cynthia.Card
     {//间谍。改变同排2个单位的锁定状态，随后汲食它们的所有战力。
         public LethoOfGulet(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
-        {
+        { 
+        if(isSpying)
+            {//cases were separated because otherwise in one case the card selection becomes random
             var cards = await Game.GetSelectPlaceCards(Card, 2, true, x => x.Status.CardRow == Card.Status.CardRow, SelectModeType.MyRow, isHasConceal: true);
             foreach (var card in cards)
-            {
+                {
                 await card.Effect.Lock(Card);
                 await Card.Effect.Drain(card.ToHealth().health, card);
-            }
+                }
             return 0;
+            }   
+        else
+            {
+               var cards = await Game.GetSelectPlaceCards(Card, 2, selectMode: SelectModeType.MyRow, filter: x => x.Status.CardRow == Card.Status.CardRow);
+               foreach (var card in cards)
+               {
+                    await card.Effect.Lock(Card);
+                    await Card.Effect.Drain(card.ToHealth().health, card);
+               }
+               return 0;
+            }
         }
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/SLeDeTansarville.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/SLeDeTansarville.cs
@@ -8,6 +8,7 @@ namespace Cynthia.Card
     public class SLeDeTansarville : CardEffect
     {//从手牌打出1张铜色/银色“特殊”牌，随后抽1张牌。
         public SLeDeTansarville(GameCard card) : base(card) { }
+        private bool needdraw = false;
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
 
@@ -21,10 +22,17 @@ namespace Cynthia.Card
             {
                 return 0;
             }
-            await Game.PlayerDrawCard(Card.PlayerIndex, 1);
             await result.Single().MoveToCardStayFirst();
-
+            needdraw = true;
             return 1;
+        }
+        public override async Task CardDownEffect(bool isSpying, bool isReveal)
+        {
+            if(needdraw)
+            {
+            await Game.PlayerDrawCard(Card.PlayerIndex, 1);
+            }    
+                return;
         }
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GameEvent/AfterCardTransform.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GameEvent/AfterCardTransform.cs
@@ -1,0 +1,15 @@
+﻿namespace Cynthia.Card
+{
+    //after a card transforms
+    public class AfterCardTransform : Event
+    {
+        public GameCard Target { get; set; }
+        public GameCard Source { get; set; }
+
+        public AfterCardTransform(GameCard target, GameCard source)
+        {
+            Target = target;
+            Source = source;
+        }
+    }
+}

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -8,7 +8,7 @@ namespace Cynthia.Card
     public static class GwentMap
     {
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 65);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 67);
         public static IDictionary<string, int> CardIdMap { get; set; }
         public static string[] CardIdIndexMap { get; set; }
 
@@ -10658,7 +10658,7 @@ namespace Cynthia.Card
                     IsDoomed = false,
                     IsCountdown = false,
                     IsDerive = false,
-                    Categories = new Categorie[]{ Categorie.ClanTuirseach},
+                    Categories = new Categorie[]{ Categorie.ClanTuirseach, Categorie.Cursed, Categorie.Cultist},
                     Flavor = "",
                     Info = "己方半场同排单位免疫来自灾厄的伤害。择一：创造一张史凯利格铜色机械单位；或使战场上所有友方机械获得2点强化。",
                     CardArtsId = "18840000",
@@ -10906,7 +10906,7 @@ namespace Cynthia.Card
                 }
             },
             {
-                "70016",//苏克鲁斯
+                "70016",//苏克鲁斯 Sukrus
                 new GwentCard()
                 {
                     CardId = "70016",
@@ -10919,7 +10919,7 @@ namespace Cynthia.Card
                     IsDoomed = false,
                     IsCountdown = false,
                     IsDerive = false,
-                    Categories = new Categorie[]{ Categorie.Support},
+                    Categories = new Categorie[]{ Categorie.Support,Categorie.ClanTuirseach},
                     Flavor = "",
                     Info = "选择手牌中的一张铜色牌，丢弃所有牌组中该牌的同名牌。",
                     CardArtsId = "d18870000",
@@ -12517,7 +12517,7 @@ namespace Cynthia.Card
                     Categories = new Categorie[]{ Categorie.Soldier,Categorie.ClanAnCraite},
                     Flavor = "尼尔弗加德渔民的恐怖经历",
                     Info = "位于手牌、牌组和己方半场时，己方每丢弃1张牌便获得1点增益。",
-                    CardArtsId = "d22430000",
+                    CardArtsId = "d22400000",
                 }
             },
                         {
@@ -12535,7 +12535,7 @@ namespace Cynthia.Card
                     IsDoomed = false,
                     IsCountdown = true,
                     IsDerive = false,
-                    Categories = new Categorie[]{ Categorie.Cultist},
+                    Categories = new Categorie[]{ Categorie.Cultist, Categorie.ClanDrummond},
                     Flavor = "我向斯瓦布洛德下跪，只向斯瓦布洛德下跪!",
                     Info = "力竭：丢弃1张手牌，然后在手牌中添加1张己方初始牌组中铜色单位牌的原始同名牌，并使其获得1点强化。",
                     CardArtsId = "d16660000",
@@ -12558,7 +12558,7 @@ namespace Cynthia.Card
                     Categories = new Categorie[]{ Categorie.ClanDrummond, Categorie.Soldier},
                     Flavor = "他们唯一比抢劫更喜欢的是杀戮。",
                     Info = "被丢弃时，使手牌、牌组所有“德拉蒙家族”单位获得1点强化。",
-                    CardArtsId = "d22400000",
+                    CardArtsId = "d22430000",
                 }
             },
                         {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/GwentServerModels/GwentServerGame.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/GwentServerModels/GwentServerGame.cs
@@ -378,7 +378,7 @@ namespace Cynthia.Card.Server
                 IsPlayersLeader[playerIndex] = false;
             //如果是直接丢墓地,触发丢墓地方法
             if (cardInfo.CardLocation.RowPosition == RowPosition.MyCemetery)
-                await card.Effect.ToCemetery();
+                await card.Effect.Discard(card);
             else
             {   //如果是法术,使用,如果是单位,打出
                 if (cardInfo.CardLocation.RowPosition == RowPosition.SpecialPlace)


### PR DESCRIPTION
Here's a second batch of content from my main PR, focusing on bug/lore/QoL/EnDescritpion fixes

- Northern Realms
   - Sile: fixed to have the effect of the special played resolve before drawing a card
- Skellige
   - Lore fixes
      - Swapped the arts for Drummond Pillager & An Craite Warlord
      - Tuirseach tag added to Sukrus
      - Cultist and Cursed tags given to Hammond
      - Drummond tag given to Knut
   - Discard
      - Allow to res doomed discarded units (like in beta)
      - Fix the discard mechanic (discard from hand and Iris Companions)
- Nilfgaard
   - Letho: fix a bug where he would trigger on random units if played on your side of the board
- Description Fixes
   - Svalblod Fanatic now says turn instead of round
   - Meve's text displays the correct value: 5