### PR TITLE
Fixed Phantom and Elder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ msbuild.wrn
 
 # Rider
 .idea
+/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Voicelines/PL/1200200/12002_2.mp3.meta
+/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Voicelines/PL/1200300/12003_4.mp3.meta

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ msbuild.wrn
 .idea
 /src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Voicelines/PL/1200200/12002_2.mp3.meta
 /src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Voicelines/PL/1200300/12003_4.mp3.meta
+/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Voicelines/PL/1200200/12002_1.mp3.meta

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ msbuild.wrn
 /src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Voicelines/PL/1200200/12002_2.mp3.meta
 /src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Voicelines/PL/1200300/12003_4.mp3.meta
 /src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Voicelines/PL/1200200/12002_1.mp3.meta
+/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Voicelines/PL/1200200/12002_5.mp3.meta

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Silver/TheApiarianPhantom.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Silver/TheApiarianPhantom.cs
@@ -4,7 +4,7 @@ using Alsein.Extensions;
 
 namespace Cynthia.Card
 {
-    [CardEffectId("70082")]//尼斯里拉
+    [CardEffectId("70085")]//尼斯里拉
     public class TheApiarianPhantom : CardEffect
     {//对1个敌军单位造成6点伤害。手牌中每有1张“狂猎”单位牌，伤害提高1点。
         public TheApiarianPhantom(GameCard card) : base(card) { }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Silver/TheThingInTheSwamp.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Silver/TheThingInTheSwamp.cs
@@ -4,7 +4,7 @@ using Alsein.Extensions;
 
 namespace Cynthia.Card
 {
-    [CardEffectId("70086")]
+    [CardEffectId("70088")]
     public class TheThingInTheSwamp : CardEffect
     {//将墓场3张铜色/银色单位牌放回牌组。
         public TheThingInTheSwamp(GameCard card) : base(card) { }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Leader/UnseenElder.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Leader/UnseenElder.cs
@@ -15,6 +15,7 @@ namespace Cynthia.Card
                 return 0;
             }
             await Card.Effect.Drain((target.CardPoint() + 1) / 2, target);
+            await target.Effect.Lock(Card);
             return 0;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Silver/Assassination.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Silver/Assassination.cs
@@ -14,7 +14,7 @@ namespace Cynthia.Card
             {
                 var result = await Game.GetSelectPlaceCards(Card, selectMode: SelectModeType.EnemyRow);
                 if (result.Count <= 0) continue;
-                await result.Single().Effect.Damage(9, Card);
+                await result.Single().Effect.Damage(7, Card);
             }
             return 0;
         }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/DimunSmuggler.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/DimunSmuggler.cs
@@ -25,3 +25,4 @@ namespace Cynthia.Card
             }
         }
     }
+}

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/DimunSmuggler.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/DimunSmuggler.cs
@@ -10,31 +10,18 @@ namespace Cynthia.Card
         public DimunSmuggler(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
-            var list = Game.PlayersCemetery[PlayerIndex].Where(x => x.Status.Group == Group.Copper && x.CardInfo().CardType == CardType.Unit);
-            if (list.Count() == 0)
             {
+                var list = Game.PlayersCemetery[Card.PlayerIndex]
+                .Where(x => x.Status.Group == Group.Copper && x.CardInfo().CardType == CardType.Unit).ToList();
+                //让玩家选择
+                var result = await Game.GetSelectMenuCards(Card.PlayerIndex, list, 2, isCanOver: true);
+                foreach (var x in result.ToList())
+                {
+                    var playerIndex = x.PlayerIndex;
+                    x.Effect.Repair();
+                    await Game.ShowCardMove(new CardLocation(RowPosition.MyDeck, RNG.Next(0, Game.PlayersDeck[playerIndex].Count)), x);
+                }
                 return 0;
             }
-            //让玩家选择一张卡
-            var result = await Game.GetSelectMenuCards
-            (Card.PlayerIndex, list.ToList(), 2, "选择一张牌返回牌组");
-            //如果玩家一张卡都没选择,没有效果
-            if (result.Count() == 0)
-            {
-                return 0;
-            }
-            //希里：冲刺的返回牌组机制，返回到随机位置
-
-
-
-            foreach (var card in result)
-            {
-
-            var range = Game.RNG.Next(0, Game.PlayersDeck[PlayerIndex].Count() + 1);
-            await card.Effect.Resurrect(new CardLocation(RowPosition.MyDeck, range), card);
-            return 0;
-            }
-        return 0;
         }
     }
-}

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -8,7 +8,7 @@ namespace Cynthia.Card
     public static class GwentMap
     {
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 70);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 71);
         public static IDictionary<string, int> CardIdMap { get; set; }
         public static string[] CardIdIndexMap { get; set; }
 


### PR DESCRIPTION
This second hotfix solves the following issues:

- Assassination damage is set as intended at 7
- Phantom ID was corrected
- Elder does lock the target
- Smuggler now puts back the 2 cards
- Thing In The Swamp ID was corrected