### PR TITLE
Hotfix - 3

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/NorthernRealms/Gold/PhilippaLodgeMistress.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/NorthernRealms/Gold/PhilippaLodgeMistress.cs
@@ -4,7 +4,7 @@ using Alsein.Extensions;
 
 namespace Cynthia.Card
 {
-    [CardEffectId("70083")]//艾勒的格哈特
+    [CardEffectId("70086")]//艾勒的格哈特
     public class PhilippaLodgeMistress : CardEffect
     {//play a bronze or silver mage from your deck, or generate and play a bronze spell
         public PhilippaLodgeMistress(GameCard card) : base(card) { }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Gold/CaranthirArFeiniel.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Gold/CaranthirArFeiniel.cs
@@ -14,8 +14,8 @@ namespace Cynthia.Card
             foreach (var target in selectCard)
             {
                 await target.Effect.Move(new CardLocation(Card.Status.CardRow, int.MaxValue), Card);
-                await Game.GameRowEffect[AnotherPlayer][Card.Status.CardRow.MyRowToIndex()].SetStatus<BitingFrostStatus>();
             }
+            await Game.GameRowEffect[AnotherPlayer][Card.Status.CardRow.MyRowToIndex()].SetStatus<BitingFrostStatus>();
             return 0;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/DimunSmuggler.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/DimunSmuggler.cs
@@ -19,7 +19,8 @@ namespace Cynthia.Card
                 {
                     var playerIndex = x.PlayerIndex;
                     x.Effect.Repair();
-                    await Game.ShowCardMove(new CardLocation(RowPosition.MyDeck, RNG.Next(0, Game.PlayersDeck[playerIndex].Count)), x);
+                    var range = Game.RNG.Next(0, Game.PlayersDeck[PlayerIndex].Count() + 1);
+                    await x.Effect.Resurrect(new CardLocation(RowPosition.MyDeck, range), x);
                 }
                 return 0;
             }


### PR DESCRIPTION
My sincerest apologies, there were some bugs left. Here are the following corrections:

- Caranthir has been fixed to spawn frost whatever the number of opposing targets
- Smuggler has been given back his DIY capacity of triggering Cerys for resurects, which is debatable but since we never spoke of removing that I put it back in
- Philippa ID was fixed