### PR TITLE
Revert the feature that made discarded doom targets not banished

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/CardEffect.cs
@@ -190,7 +190,7 @@ namespace Cynthia.Card
             });
             async Task sendEventTask()
             {
-                if ((Card.Status.IsDoomed && isDead) || (isNeedBanish && Card.Status.Strength <= 0 && Card.Status.Type == CardType.Unit))//如果是佚亡,放逐
+                if (Card.Status.IsDoomed || (isNeedBanish && Card.Status.Strength <= 0 && Card.Status.Type == CardType.Unit))//如果是佚亡,放逐
                 {
                     await Banish();
                     if (isNeedSentEvent && discardInfo.isDiscard && !deadposition.RowPosition.IsOnPlace())


### PR DESCRIPTION
reverted the not banished discarded doom targets feature.

As this was not discussed here is a PR to delete the feature.

Originally in Beta Gwent, at least until Midwinter (possibly later) discarded doomed targets were not banished and could be resurected. This was balanced as the purpose of the doom tag is to prevent some cards from being played twice, which wasn't the case here. This feature enabled interesting plays with Skellige, as it lacks good discard targets: mainly freias can be discarded and get resurected by Sigdriga or Restore, allowing additional Cerys procs for instance. The play is good but not OP as you sacrifice a 0 tempo discard to get the Freia in the graveyard. Also, comparatively to Midwinter, freias cannot resurrect themselves anymore, so there"s no way this is OP. As a conclusion I think the features really promotes forward thinking with discard and makes the game more interesting while being balanced and is a return to original Gwent gameplay.