### PR TITLE
Hotfix 4

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Gold/CaranthirArFeiniel.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Gold/CaranthirArFeiniel.cs
@@ -10,7 +10,7 @@ namespace Cynthia.Card
         public CaranthirArFeiniel(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
-            var selectCard = await Game.GetSelectPlaceCards(Card, 2, selectMode: SelectModeType.AllRow, filter: x => x.Status.CardRow != Card.Status.CardRow);
+            var selectCard = await Game.GetSelectPlaceCards(Card, 2, selectMode: SelectModeType.EnemyRow, filter: x => x.Status.CardRow != Card.Status.CardRow);
             foreach (var target in selectCard)
             {
                 await target.Effect.Move(new CardLocation(Card.Status.CardRow, int.MaxValue), Card);


### PR DESCRIPTION
- updated Caranthir to only target ennemies
- I would like to add a fix of the changed Artorius Vigo because currently his reveal effect doesn't trigger cards fire scorpion (but it does for foot soliders) but I still need some time to fix that.