### PR TITLE
Nerf CintrianFieldMedic.cs

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/NorthernRealms/Copper/CintrianFieldMedic.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/NorthernRealms/Copper/CintrianFieldMedic.cs
@@ -14,7 +14,7 @@ namespace Cynthia.Card
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
             //选择一张场上的卡
-            var selectList = await Game.GetSelectPlaceCards(Card, selectMode: SelectModeType.MyRow, filter: x => x.Is(Group.Copper, CardType.Unit, filter: x => x.Status.CardId != Card.Status.CardId));
+            var selectList = await Game.GetSelectPlaceCards(Card, selectMode: SelectModeType.MyRow, filter: x => x.Is(Group.Copper, CardType.Unit, filter: x => x.Status.CardId != Card.Status.CardId && !x.HasAnyCategorie(Categorie.Support)));
             if (!selectList.TrySingle(out var target))
             {
                 return 0;


### PR DESCRIPTION
As requested by YFY, here is a PR that nerfs the Cintrian Field medic, which won't be able to put back support cards in the deck.
I still need to do the translation though.