### PR TITLE
LonelyChampion Hotfix

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Neutral/Silver/LonelyChampion.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Neutral/Silver/LonelyChampion.cs
@@ -11,7 +11,7 @@ namespace Cynthia.Card
         public async Task HandleEvent(AfterTurnOver @event)
         {
             var targets = Game.GetPlaceCards(PlayerIndex).Where(x => x != Card).ToList();
-            if (@event.PlayerIndex == PlayerIndex && targets.Count() == 0)
+            if (@event.PlayerIndex == PlayerIndex && targets.Count() == 0 && card.Status.CardRow.IsOnPlace())
             {
                 await Card.Effect.Boost(4, Card);
             }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Neutral/Silver/LonelyChampion.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Neutral/Silver/LonelyChampion.cs
@@ -11,7 +11,7 @@ namespace Cynthia.Card
         public async Task HandleEvent(AfterTurnOver @event)
         {
             var targets = Game.GetPlaceCards(PlayerIndex).Where(x => x != Card).ToList();
-            if (@event.PlayerIndex == PlayerIndex && targets.Count() == 0 && card.Status.CardRow.IsOnPlace())
+            if (@event.PlayerIndex == PlayerIndex && targets.Count() == 0 && Card.Status.CardRow.IsOnPlace())
             {
                 await Card.Effect.Boost(4, Card);
             }


### PR DESCRIPTION
@neal2018 A small hotfix for Lonely Champion, several people complained about it on the Discord and say they might take a break until it is fixed. In the proposed hotfix its effect now requires for it to be on the board. Unitless decks are always unhealthy for the game and this is beyonf overpowered. I don't want to overstep, this is just a hotfix, you can rebalance the card howerver you want when you do the next update.

![image](https://github.com/LegacyGwent/LegacyGwent/assets/48692951/b0de71c0-6679-4add-a958-bdba6aa8194b)
