### PR TITLE
Monster Moonlight and Beast - WIP - For feedback purposes

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -8,7 +8,7 @@ namespace Cynthia.Card
     public static class GwentMap
     {
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 99);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 100);
         public static IDictionary<string, int> CardIdMap { get; set; }
         public static string[] CardIdIndexMap { get; set; }
 


### PR DESCRIPTION
The reviewers and I always thought beasts and moonlight were an interesting synergy that felt a bit unfinished, so here are the first cards we approve to buff it and turn it into an actual archetype.
- New Gold: Sir Scratch a lot: Beast and Cursed - "Deploy: strengthen all allied beasts by 1 wherever they are, then boost them by 1 if they are under full moon." _ The full moon archetype needs a buff, and a good gold would go a long way for that (art https://gwent.one/en/card/203081)
- New Bronze: Giant Toad (art https://gwent.one/img/assets/medium/art/3948.jpg):  Beast. 7 strength "Deploy: Boost a beast in your deck by 2.   Death wish: Boost a random smallest beast in your deck by 4."

Can you please forward to QQ? Thanks a lot.