### PR TITLE
Corsair Rebalance - WIP - For feedback purposes

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -8,7 +8,7 @@ namespace Cynthia.Card
     public static class GwentMap
     {
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 99);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 100);
         public static IDictionary<string, int> CardIdMap { get; set; }
         public static string[] CardIdIndexMap { get; set; }
 


### PR DESCRIPTION
Control Skellige and axemen suck; we suggest either a return of corsair to 3pts like in beta or the following

The ship topic touches historic cards, which I regret, but is in our opinion needed to compensate for the decision to nerf corsair compared to beta and make historic archetypes playable again. 
- Corsair: 1pt -> 3pts. I believe this is essential for axemen, cursed (they can't be damaged at 1) and control and that it was a core beta card, enabling many decks. We think it's a good compromise between 1 and 3