### PR TITLE
Fiend/Manticore buffs - WIP - For feedback purposes

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -8,7 +8,7 @@ namespace Cynthia.Card
     public static class GwentMap
     {
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 99);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 100);
         public static IDictionary<string, int> CardIdMap { get; set; }
         public static string[] CardIdIndexMap { get; set; }
 


### PR DESCRIPTION
Hi, here is a bunch of miscelanious buffs to historically underpowered cards. The design idea is to touch them as little as possible but give them an extra something. The beta ones were weak already in beta.

- Manticore: 15 power: deploy, set its strength to 13 // ghould / toad prince synergy
- Fiend: 12 power, damage self by 1 on deploy if there are no relicts on the row // ghould / toad prince synergy