### PR TITLE
 Ambush rebalance - WIP - For feedback purposes

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -8,7 +8,7 @@ namespace Cynthia.Card
     public static class GwentMap
     {
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 99);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 100);
         public static IDictionary<string, int> CardIdMap { get; set; }
         public static string[] CardIdIndexMap { get; set; }
 


### PR DESCRIPTION
The basic principle is we think ambushes were a core and fun mechanic in gwent when it wasn't overpowered, for instance before midwinter. We know it's a dangerous mechanic, but we think that if we keep the number of playable ambush cards low (it's currently around 0), the guessing game is fair and the archetype can recover from the Midwinter powercreep while being fair and interesting. That's why for the moment we don't want to add new ambushes, just to make current ones a bit more playable. This is why we suggest the following:

- Toruviel: STR 6 -> STR 4, boost by 2 -> boost by 3 
- Malena: 7 STR => 8 STR
- Probably -1 to sapper, especially if there are more buffs approved
- Morenn Forest Child is a wasted artwork, she should get a rework
- Morenn (regular one): flip at the end of the round (doing no damage) if she was not activated