### PR TITLE
bug fixes

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Gold/Renew.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Gold/Renew.cs
@@ -11,7 +11,7 @@ namespace Cynthia.Card
         public override async Task<int> CardUseEffect()
         {
             var list = Game.PlayersCemetery[PlayerIndex]
-            .Where(x => x.Status.Group == Group.Gold && x.CardInfo().CardType == CardType.Unit).ToList();
+            .Where(x => x.Status.Group == Group.Gold && x.CardInfo().CardType == CardType.Unit && x.CardInfo().CardId != "70014").ToList();
             //让玩家选择一张卡
             var result = await Game.GetSelectMenuCards
             (Card.PlayerIndex, list, 1, "选择复活一张牌");

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Copper/Spotter.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Copper/Spotter.cs
@@ -14,7 +14,7 @@ namespace Cynthia.Card
                 (Card, filter: x => x.Status.IsReveal && (x.Status.Group == Group.Copper || x.Status.Group == Group.Silver), selectMode: SelectModeType.AllHand);
             if (result.Count() == 0) return 0;
             var point = result.Single().Status.Strength;
-            await Card.Effect.Boost(point/2, Card);
+            await Card.Effect.Boost((point +1)/2, Card);
             return 0;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -8,7 +8,7 @@ namespace Cynthia.Card
     public static class GwentMap
     {
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 108);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 109);
         public static IDictionary<string, int> CardIdMap { get; set; }
         public static string[] CardIdIndexMap { get; set; }
 
@@ -14119,7 +14119,7 @@ namespace Cynthia.Card
                     IsDoomed = false,
                     IsCountdown = false,
                     IsDerive = false,
-                    Categories = new Categorie[]{ Categorie.Special,Categorie.Tactic},
+                    Categories = new Categorie[]{ Categorie.Special,Categorie.Item},
                     Flavor = "一条结实的皮革腰带，显然是为泰坦所打造，至今没有谁的躯干能与之匹配。尽管穿上后可以获得巨人般的神力，却无法获得巨人般的体型。",
                     Info = "使一名友方单位获得等同于其基础战力的增益，如果该单位是食人魔，则先强化2点。",
                     CardArtsId = "203266",


### PR DESCRIPTION
- giant's belt is now an item and not a tactic
- tactical advantage cannot be resurected by renew anymore
- Spotter buff rounds up instead of down, as described in the original PR.