### PR TITLE
show base strenght on hover!

### DIFF
--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/Card/ArtCard.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/Card/ArtCard.cs
@@ -156,13 +156,8 @@ public class ArtCard : MonoBehaviour
         }
         else
             ArmorShow.SetActive(false);
-        Strength.text = (CurrentCore.Strength + CurrentCore.HealthStatus).ToString();
-        if (CurrentCore.HealthStatus > 0)
-            Strength.color = ClientGlobalInfo.GreenColor;
-        if (CurrentCore.HealthStatus == 0)
-            Strength.color = ClientGlobalInfo.NormalColor;
-        if (CurrentCore.HealthStatus < 0)
-            Strength.color = ClientGlobalInfo.RedColor;
+        Strength.text = (CurrentCore.Strength).ToString();
+        Strength.color = ClientGlobalInfo.NormalColor;
         // FactionIcon.GetComponent<RectTransform>().sizeDelta = new Vector2(50, 50 + (iconCount == 0 ? 1 : iconCount) * 50);
         //-----------------------------------------------
     }


### PR DESCRIPTION
Changed what is showed when hover over the card. Now base strenght is showing. Would make game much easier as base strength wasn't visible anywhere in game
![image](https://github.com/user-attachments/assets/02a4b8a4-ef24-4796-b87a-aec649395de5)
