### PR TITLE
Rightclick mobile

### DIFF
--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Scenes/RightClick.unity
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Scenes/RightClick.unity
@@ -211,7 +211,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 414.78333, y: 0}
+  m_AnchoredPosition: {x: 414.34827, y: 0}
   m_SizeDelta: {x: 1000, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &224801133
@@ -308,7 +308,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 414.78333, y: 0}
+  m_AnchoredPosition: {x: 414.34827, y: 0}
   m_SizeDelta: {x: 1000, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &226036380
@@ -715,7 +715,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 414.78333, y: 0}
+  m_AnchoredPosition: {x: 414.34827, y: 0}
   m_SizeDelta: {x: 1000, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &861243428
@@ -1032,7 +1032,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 414.78333, y: 0}
+  m_AnchoredPosition: {x: 414.34827, y: 0}
   m_SizeDelta: {x: 1000, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1097067746
@@ -1673,9 +1673,9 @@ RectTransform:
   m_Father: {fileID: 1701228058}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 596, y: -444}
+  m_AnchorMin: {x: 0.5115633, y: 0}
+  m_AnchorMax: {x: 0.5115633, y: 0}
+  m_AnchoredPosition: {x: 574, y: 50}
   m_SizeDelta: {x: 637.52856, y: 85.93671}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1972593811
@@ -2418,27 +2418,27 @@ PrefabInstance:
     - target: {fileID: 4889809228523219807, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809228523219807, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809228523219807, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 101.5873
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809228523219807, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -21.925926
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809228523219807, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 203.1746
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809228731434142, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
@@ -2593,27 +2593,27 @@ PrefabInstance:
     - target: {fileID: 4889809228965257599, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 513.1999
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809228965257599, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1026.3998
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809228965257599, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809228965257599, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809228965257599, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -130.9442
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809229032611122, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
@@ -2653,27 +2653,27 @@ PrefabInstance:
     - target: {fileID: 4889809229715111678, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809229715111678, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809229715111678, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 47.89116
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809229715111678, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -61.479527
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809229715111678, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 95.78232
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4889809229715111679, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
@@ -3022,7 +3022,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 288.4, y: -274}
+  m_AnchoredPosition: {x: 288.4004, y: -274}
   m_SizeDelta: {x: 560, y: 560}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &6503477938084249353
@@ -3043,8 +3043,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 596, y: 34}
-  m_SizeDelta: {x: 278.83, y: 385.8}
+  m_AnchoredPosition: {x: 596, y: 40}
+  m_SizeDelta: {x: 267.41, y: 370}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &6504165456945571277
 RectTransform:
@@ -3063,7 +3063,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.3899994, y: 0}
+  m_AnchoredPosition: {x: 0.38964844, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &6504286235297384623

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Scenes/RightClick.unity
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Scenes/RightClick.unity
@@ -1334,8 +1334,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1093.601, y: 0}
-  m_SizeDelta: {x: 1093.6011, y: 0}
+  m_AnchoredPosition: {x: 1074.3, y: -0}
+  m_SizeDelta: {x: 1074.2705, y: 0}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1363404575
 MonoBehaviour:
@@ -1541,7 +1541,7 @@ MonoBehaviour:
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1920, y: 1080}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
+  m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
@@ -2398,12 +2398,17 @@ PrefabInstance:
     - target: {fileID: 502617330678259436, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 562.4
       objectReference: {fileID: 0}
     - target: {fileID: 502617330678259436, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 502617330678259436, guid: f8f3c464ef31e9b41b5012e17438da41,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1249.5658
       objectReference: {fileID: 0}
     - target: {fileID: 4889809228486555894, guid: f8f3c464ef31e9b41b5012e17438da41,
         type: 3}

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Scenes/RightClick.unity
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Resources/Scenes/RightClick.unity
@@ -211,7 +211,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 414.34827, y: 0}
+  m_AnchoredPosition: {x: 414.7834, y: 0}
   m_SizeDelta: {x: 1000, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &224801133
@@ -308,7 +308,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 414.34827, y: 0}
+  m_AnchoredPosition: {x: 414.7834, y: 0}
   m_SizeDelta: {x: 1000, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &226036380
@@ -715,7 +715,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 414.34827, y: 0}
+  m_AnchoredPosition: {x: 414.7834, y: 0}
   m_SizeDelta: {x: 1000, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &861243428
@@ -1032,7 +1032,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 414.34827, y: 0}
+  m_AnchoredPosition: {x: 414.7834, y: 0}
   m_SizeDelta: {x: 1000, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1097067746
@@ -3041,9 +3041,9 @@ RectTransform:
   m_Father: {fileID: 1701228058}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 596, y: 40}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 596, y: -500}
   m_SizeDelta: {x: 267.41, y: 370}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &6504165456945571277

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/EditorMenu/EditorInfo.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/EditorMenu/EditorInfo.cs
@@ -106,6 +106,9 @@ public class EditorInfo : MonoBehaviour
     public GameObject DeckCodeInputBackGround;
     public InputField DeckCodeInputName;
     public InputField DeckCodeInputCode;
+    // mobile right click
+    private float pressTime = 0;
+    private bool IsRightClickMobile = false;
     //------------------------------------------------
     private LocalizationService _translator;
 
@@ -469,7 +472,38 @@ public class EditorInfo : MonoBehaviour
     }
     private void Update()
     {
-        if (Input.GetMouseButtonDown(1))
+#if UNITY_ANDROID || UNITY_IOS
+        if (Input.touchCount <= 0) return;
+        var touch = Input.GetTouch(0);
+        switch(touch.phase)
+        {
+            case TouchPhase.Began:
+                pressTime = 0;
+                IsRightClickMobile = false;
+                break;
+            case TouchPhase.Stationary:
+                pressTime += Time.deltaTime;
+                if (pressTime > 1f)
+                {
+                    IsRightClickMobile = true;
+                    pressTime = 0;
+                }
+                break;
+            case TouchPhase.Moved:
+                pressTime = 0;
+                IsRightClickMobile = false;
+                break;
+            case TouchPhase.Ended:
+                IsRightClickMobile = false;
+                pressTime = 0;
+                break;
+            case TouchPhase.Canceled:
+                IsRightClickMobile = false;
+                pressTime = 0;
+                break;
+        }
+#endif
+        if (Input.GetMouseButtonDown(1) || IsRightClickMobile)
         {
             if (EditorArtCard.gameObject.activeSelf || ShowArtCard.gameObject.activeSelf)
             {
@@ -478,7 +512,7 @@ public class EditorInfo : MonoBehaviour
                 //RighClickActive=true;
                 SceneManager.LoadScene("RightClick", LoadSceneMode.Additive);
             }
-        }
+        }        
     }
             
     public void ClickSwitchUICard(CardStatus card)

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameEvent.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameEvent.cs
@@ -87,6 +87,11 @@ public class GameEvent : MonoBehaviour
     private GlobalUIService _uiService;
     public RopeController ropeController;
     public bool IsMobileClickDown = false;
+    // private float holdTime = 2f; // Time to consider if a longtap on mobile
+    // private bool isTapped = false;
+    // private float timeSinceLastTap = 0f;
+    private float pressTime = 0;
+    private bool IsRightClickMobile = false;
     private void Awake()
     {
         (sender, receiver) = Tube.CreateSimplex();
@@ -440,11 +445,11 @@ public class GameEvent : MonoBehaviour
     //右键点击之类的
     private void OnMouseOver()
     {
-#if UNITY_ANDROID || UNITY_IOS
-        if (Input.GetMouseButtonDown(0))
-#else
-        if (Input.GetMouseButtonDown(1))
-#endif
+// #if UNITY_ANDROID || UNITY_IOS
+//         if (Input.GetMouseButtonDown(0))
+// #else
+//         if (Input.GetMouseButtonDown(1))
+// #endif
         {
             if (!RighClickActive)
             {
@@ -468,12 +473,23 @@ public class GameEvent : MonoBehaviour
                         Debug.Log("右键点击了卡牌");
                         var card = trueitem.First();
                         Debug.Log("卡牌On?:" + card.GetComponent<CardMoveInfo>().IsOn);
-#if !UNITY_ANDROID && !UNITY_IOS
-                        RightClickedCardID = card.GetComponent<CardShowInfo>().CurrentCore.CardId;
-                        if (!string.IsNullOrEmpty(RightClickedCardID))
-                        {
-                            RighClickActive = true;
-                            SceneManager.LoadScene("RightClick", LoadSceneMode.Additive);
+#if !UNITY_ANDROID && !UNITY_IOS                           
+                            RightClickedCardID = card.GetComponent<CardShowInfo>().CurrentCore.CardId;
+                            if (!string.IsNullOrEmpty(RightClickedCardID))
+                            {
+                                RighClickActive = true;
+                                SceneManager.LoadScene("RightClick", LoadSceneMode.Additive);
+                            }
+#elif UNITY_ANDROID || UNITY_IOS
+                        if(IsRightClickMobile)
+                        {            
+                            RightClickedCardID = card.GetComponent<CardShowInfo>().CurrentCore.CardId;
+                            if (!string.IsNullOrEmpty(RightClickedCardID))
+                            {
+                                // SelectCard = null;
+                                RighClickActive = true;
+                                SceneManager.LoadScene("RightClick", LoadSceneMode.Additive);
+                            }
                         }
 #endif
                         break;
@@ -491,6 +507,39 @@ public class GameEvent : MonoBehaviour
         {
             SendSurrender();
         }
+        #if UNITY_ANDROID || UNITY_IOS
+            if (Input.touchCount <= 0) return;
+    
+        var touch = Input.GetTouch(0);
+
+        switch(touch.phase)
+        {
+
+            case TouchPhase.Began:
+                pressTime = 0;
+                IsRightClickMobile = false;
+                break;
+            case TouchPhase.Stationary:
+                pressTime += Time.deltaTime;
+                if (pressTime > 0,75f)
+                {
+                    IsRightClickMobile = true;
+                    pressTime = 0;
+                }
+                break;
+            case TouchPhase.Moved:
+                pressTime = 0;
+                IsRightClickMobile = false;
+                break;
+            case TouchPhase.Ended:
+                IsRightClickMobile = false;
+                pressTime = 0;
+                break;
+            case TouchPhase.Canceled:
+                IsRightClickMobile = false;
+                pressTime = 0;
+                break;
+        # endif
         var onObjects = GetMouseAllRaycast();//获取鼠标穿透的所有物体
         //画箭
         DrawArrows();

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameEvent.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameEvent.cs
@@ -87,9 +87,6 @@ public class GameEvent : MonoBehaviour
     private GlobalUIService _uiService;
     public RopeController ropeController;
     public bool IsMobileClickDown = false;
-    // private float holdTime = 2f; // Time to consider if a longtap on mobile
-    // private bool isTapped = false;
-    // private float timeSinceLastTap = 0f;
     private float pressTime = 0;
     private bool IsRightClickMobile = false;
     private void Awake()
@@ -486,7 +483,6 @@ public class GameEvent : MonoBehaviour
                             RightClickedCardID = card.GetComponent<CardShowInfo>().CurrentCore.CardId;
                             if (!string.IsNullOrEmpty(RightClickedCardID))
                             {
-                                // SelectCard = null;
                                 RighClickActive = true;
                                 SceneManager.LoadScene("RightClick", LoadSceneMode.Additive);
                             }
@@ -521,7 +517,7 @@ public class GameEvent : MonoBehaviour
                 break;
             case TouchPhase.Stationary:
                 pressTime += Time.deltaTime;
-                if (pressTime > 0,75f)
+                if (pressTime > 0.75f)
                 {
                     IsRightClickMobile = true;
                     pressTime = 0;
@@ -539,6 +535,7 @@ public class GameEvent : MonoBehaviour
                 IsRightClickMobile = false;
                 pressTime = 0;
                 break;
+        }
         # endif
         var onObjects = GetMouseAllRaycast();//获取鼠标穿透的所有物体
         //画箭

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameEvent.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameEvent.cs
@@ -87,7 +87,7 @@ public class GameEvent : MonoBehaviour
     private GlobalUIService _uiService;
     public RopeController ropeController;
     public bool IsMobileClickDown = false;
-    private float pressTime = 0;
+    private float pressTime = 0; // time pressed on mobile
     private bool IsRightClickMobile = false;
     private void Awake()
     {
@@ -484,8 +484,6 @@ public class GameEvent : MonoBehaviour
                             if (!string.IsNullOrEmpty(RightClickedCardID))
                             {
                                 DragCard = null;
-                                // SelectModeCard = null;
-                                // DropTaget = null;
                                 CurrentPlace = CardUseInfo.ReSet;
                                 CurrentPlayCard = null;
                                 ResetAllTem();
@@ -523,7 +521,7 @@ public class GameEvent : MonoBehaviour
                 break;
             case TouchPhase.Stationary:
                 pressTime += Time.deltaTime;
-                if (pressTime > 0.75f)
+                if (pressTime > 0.75f && DropTaget == null)
                 {
                     IsRightClickMobile = true;
                     pressTime = 0;
@@ -532,6 +530,7 @@ public class GameEvent : MonoBehaviour
             case TouchPhase.Moved:
                 pressTime = 0;
                 IsRightClickMobile = false;
+                
                 break;
             case TouchPhase.Ended:
                 IsRightClickMobile = false;

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameEvent.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameEvent.cs
@@ -483,6 +483,12 @@ public class GameEvent : MonoBehaviour
                             RightClickedCardID = card.GetComponent<CardShowInfo>().CurrentCore.CardId;
                             if (!string.IsNullOrEmpty(RightClickedCardID))
                             {
+                                DragCard = null;
+                                // SelectModeCard = null;
+                                // DropTaget = null;
+                                CurrentPlace = CardUseInfo.ReSet;
+                                CurrentPlayCard = null;
+                                ResetAllTem();
                                 RighClickActive = true;
                                 SceneManager.LoadScene("RightClick", LoadSceneMode.Additive);
                             }

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameUIInfo/GameCardShowControl.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameUIInfo/GameCardShowControl.cs
@@ -143,17 +143,10 @@ public class GameCardShowControl : MonoBehaviour
                 IsRightClickMobile = false;
                 break;
             case TouchPhase.Stationary:
-                // if (pressTime > 0.5f)
-                // {
-                //     DisableClickCard = true;
-                // }
                 pressTime += Time.deltaTime;
-                if (pressTime >0.9f)
-                {
-                    DisableClickCard = true;
-                }
                 if (pressTime > 1f)
                 {
+                    DisableClickCard = true; // disable click to avoid mulliganing when keeping a card pressed
                     IsRightClickMobile = true;
                     pressTime = 0;
                 }
@@ -244,6 +237,7 @@ public class GameCardShowControl : MonoBehaviour
         switch (_nowUseMenuType)
         {
             case UseCardShowType.Mulligan:
+                if (DisableClickCard == true) break;
                 if (IsUseMenuShow)
                     await sender.SendAsync<int>(index);
                 break;

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameUIInfo/GameCardShowControl.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameUIInfo/GameCardShowControl.cs
@@ -54,8 +54,10 @@ public class GameCardShowControl : MonoBehaviour
     //
     private ITubeInlet sender;
     private ITubeOutlet receiver;
-    //
-
+    // mobile right click
+    private float pressTime = 0;
+    private bool IsRightClickMobile = false;
+    private bool DisableClickCard = false;
     //TEST
     private void OnMouseOver()
     {
@@ -87,6 +89,34 @@ public class GameCardShowControl : MonoBehaviour
             }
             
         }
+#elif UNITY_ANDROID || UNITY_IOS
+        if (IsRightClickMobile)
+        {
+            if (ArtCardIsShowed.activeSelf)
+            {
+                if (_nowShowType == MenuShowType.UseCard)
+                {
+                    ClickedId = UseCardList[LastHoveredCard].CardId;
+                }
+                else if (_nowShowType == MenuShowType.EnemyCemetery)
+                {
+                    ClickedId  = EnemyCemetery[LastHoveredCard].CardId;
+                }
+                else if (_nowShowType == MenuShowType.MyCemetery)
+                {
+                    ClickedId  = MyCemetery[LastHoveredCard].CardId;
+                }
+                else if (_nowShowType == MenuShowType.MyDeck)
+                {
+                    ClickedId  = MyDeck[LastHoveredCard].CardId;
+                }
+                Debug.Log("RightClicked Card of ID: "+ClickedId);
+                GameEvent.RighClickActive=true;
+                GameEvent.RightClickedCardID=ClickedId;
+                IsRightClickMobile = false;
+                SceneManager.LoadScene("RightClick", LoadSceneMode.Additive);
+            }            
+        }        
 #endif
     }
     //END TEST
@@ -97,7 +127,54 @@ public class GameCardShowControl : MonoBehaviour
     }
     private LocalizationService _translator => DependencyResolver.Container.Resolve<LocalizationService>();
     private bool IsAutoPlay => DependencyResolver.Container.Resolve<GwentClientService>().IsAutoPlay;
+#if UNITY_ANDROID || UNITY_IOS    
+    private void Update()
+    {
 
+        if (Input.touchCount <= 0) return;
+    
+        var touch = Input.GetTouch(0);
+
+        switch(touch.phase)
+        {
+
+            case TouchPhase.Began:
+                pressTime = 0;
+                IsRightClickMobile = false;
+                break;
+            case TouchPhase.Stationary:
+                // if (pressTime > 0.5f)
+                // {
+                //     DisableClickCard = true;
+                // }
+                pressTime += Time.deltaTime;
+                if (pressTime >0.9f)
+                {
+                    DisableClickCard = true;
+                }
+                if (pressTime > 1f)
+                {
+                    IsRightClickMobile = true;
+                    pressTime = 0;
+                }
+                break;
+            case TouchPhase.Moved:
+                pressTime = 0;
+                IsRightClickMobile = false;
+                break;
+            case TouchPhase.Ended:
+                IsRightClickMobile = false;
+                pressTime = 0;
+                DisableClickCard = false;
+                break;
+            case TouchPhase.Canceled:
+                IsRightClickMobile = false;
+                pressTime = 0;
+                DisableClickCard = false;
+                break;
+        }
+    }
+#endif
     //------------------------------------------------------------------------------------------
     public void OpenButtonClick()//显示卡牌
     {
@@ -187,6 +264,7 @@ public class GameCardShowControl : MonoBehaviour
                 }
                 else
                 {
+                    if (DisableClickCard == true) break;
                     card.IsSelect = true;
                     NowSelect.Add(index);
                     if (NowSelect.Count >= NowSelectTotal)


### PR DESCRIPTION
Adds the "right click" menu to mobile when holding down a card in game or in the deckbuilder.
The scrollbar for linked cards, despite my best efforts, is buggy (works if you insist) in the deckbuilder view of the feature (works fine in-game). This seems to be due to some issues Unity 2019 has with raycast, since it's still usable and the feature is 99% complete I think I'll realease as if anyway.