### PR TITLE
Taunt and GG optimizations

### DIFF
--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Code/GwentGGService.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Code/GwentGGService.cs
@@ -30,7 +30,14 @@ namespace Cynthia.Card.Client
         public ClientState ClientState { get; set; } = ClientState.Standby;
         public Task<string> DisplayGG()
         {
-            return receiver.ReceiveAsync<string>();
+            try
+            {
+                return receiver.ReceiveAsync<string>();
+            }
+            catch
+            {
+                return Task.Delay(1).ContinueWith(t => ""); // if no taunt was received yet, return "" to avoid errors
+            }
         }
 
         public GwentGGService(IContainer container, GlobalUIService globalUIService)

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameUIInfo/GameResultControl.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameUIInfo/GameResultControl.cs
@@ -18,8 +18,6 @@ public class GameResultControl : MonoBehaviour
     public Text EnemyName;
     public string enemyname;
     public string myname;
-    private float timer=4;
-    private float interval=6;
     //三个回合的结果数字
     public Text Round1MyPoint;
     public Text Round1EnemyPoint;
@@ -221,15 +219,7 @@ public class GameResultControl : MonoBehaviour
     }
     void Update()
     {
-
-        if (timer<interval)
-        {
-            timer=timer+Time.deltaTime;
-        }
-        else
-        {
             DisplayGGObject();
-        }
     }
     private async void DisplayGGObject()
     {

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/TrinketsMenu/Taunts.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/TrinketsMenu/Taunts.cs
@@ -82,12 +82,11 @@ public class Taunts : MonoBehaviour // This script controls the behaviour of the
     }
     public async void ReceiveTaunt() // when you receive an enemytaunt from server, play its audio and write its text
     {
-        IsAwaiting = true;
         if (IsEnemyNotMute)
         {
             
-            string tauntID = await _clientService.PlayTaunt();
-            if (tauntID.Length > 1)
+            string tauntID = await _clientService.PlayTaunt(); // if no taunt is received, tauntID will be ""
+            if (tauntID.Length > 1) 
             {
                 EnemyTaunt.SetActive(true);
                 PlayTaunt(tauntID);
@@ -96,7 +95,6 @@ public class Taunts : MonoBehaviour // This script controls the behaviour of the
             }
             
         }
-        IsAwaiting = false;
     }
     public void PlayMyTaunt(string mytaunt) // play my taunt, write its text and send it to the server
     {


### PR DESCRIPTION
@neal2018 Here is the update I promised on the workings of the GG feature.

The goal was to replicate the syntax you had suggested me on the taunts feature to avoid creating endless threads that await for a GG to be received, which was to check if there was already a thread awaiting in the update loop before doing the await.

I realized that since I had written a `try receiver... / catch return ""` on my receiver in the Taunts, I didn't need to check for that: the receiver always returns an anwser so no threads get lost.

I removed the bits of code that were useless (and realized the code that went into production wasn't actually checking anything, but it didn't cause issues because of the try/catch) and replicated the logic for the GG feature.

So I hope I was clear and that was the correct thing to do. Thanks!