### PR TITLE
Season end automation

### DIFF
--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/TrinketsMenu/TrinketsInfo.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/TrinketsMenu/TrinketsInfo.cs
@@ -217,8 +217,9 @@ public class TrinketsInfo : MonoBehaviour // this script controls the behaviour 
             }
         }
     }
-    public void TrinketsButtonClicked()
+    public async void TrinketsButtonClicked()
     {
+        UpdateUserInfo();
         MainUI.SetActive(false);
         TrinketsUI.SetActive(true);
         GameProfile.SetActive(false);
@@ -230,5 +231,11 @@ public class TrinketsInfo : MonoBehaviour // this script controls the behaviour 
         TrinketsUI.SetActive(false);
         GameProfile.SetActive(true);
     }
+
+    private async void UpdateUserInfo() // refresh user info from server
+    {
+       _clientService.User = await _clientService.QueryUserInfo(_clientService.User.UserName, _clientService.User.PassWord); 
+    }
+    
 
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentDatabaseService.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentDatabaseService.cs
@@ -84,7 +84,7 @@ namespace Cynthia.Card.Server
             int GGsReceived = 0;
             ownedtitles.Add("NoBorder");
             decks.Add(GwentDeck.CreateBasicDeck(1));
-            temp.InsertOne(new UserInfo { UserName = username, PassWord = password, PlayerName = playername, Decks = decks, MMR = 4400, OwnedAvatars =ownedavatars, OwnedBorders = ownedborders});
+            temp.InsertOne(new UserInfo { UserName = username, PassWord = password, PlayerName = playername, Decks = decks, MMR = initMMR, OwnedAvatars =ownedavatars, OwnedBorders = ownedborders});
             return true;
         }
         public UserInfo Login(string username, string password)

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentDatabaseService.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentDatabaseService.cs
@@ -5,7 +5,7 @@ using MongoDB.Driver.Linq;
 using MongoDB.Driver;
 using MongoDB.Bson;
 using Cynthia.Card;
-
+using System.Threading.Tasks;
 
 namespace Cynthia.Card.Server
 {
@@ -67,7 +67,7 @@ namespace Cynthia.Card.Server
             // _collection.Update(x => x.UserName == username, user);
             return true;
         }
-        const int initMMR = 3400;
+        public int initMMR = 3400;
         public bool Register(string username, string password, string playername)
         {
             var temp = GetUserInfo();
@@ -84,7 +84,7 @@ namespace Cynthia.Card.Server
             int GGsReceived = 0;
             ownedtitles.Add("NoBorder");
             decks.Add(GwentDeck.CreateBasicDeck(1));
-            temp.InsertOne(new UserInfo { UserName = username, PassWord = password, PlayerName = playername, Decks = decks, MMR = initMMR, OwnedAvatars =ownedavatars, OwnedBorders = ownedborders});
+            temp.InsertOne(new UserInfo { UserName = username, PassWord = password, PlayerName = playername, Decks = decks, MMR = 4400, OwnedAvatars =ownedavatars, OwnedBorders = ownedborders});
             return true;
         }
         public UserInfo Login(string username, string password)
@@ -437,6 +437,20 @@ namespace Cynthia.Card.Server
             }
 
             return str;
+        }
+
+        public IEnumerable<UserInfo> GetAllPlayers()
+        {
+            return GetUserInfo().Find(_ => true).ToList();
+        }
+
+        public async Task ResetPlayerMMR(string username, int baseMMR)
+        {
+            var filter = Builders<UserInfo>.Filter.Eq(x => x.UserName, username);
+            var update = Builders<UserInfo>.Update
+                .Set(x => x.MMR, baseMMR);
+
+            await GetUserInfo().UpdateOneAsync(filter, update);
         }
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/ScheduledEventService.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/ScheduledEventService.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+
+namespace Cynthia.Card.Server
+{
+    public class ScheduledEventService : BackgroundService
+    {
+        private readonly ILogger<ScheduledEventService> _logger;
+        private readonly GwentServerService _gwentServerService;
+        private readonly GwentDatabaseService _databaseService;
+        public ScheduledEventService(
+            ILogger<ScheduledEventService> logger,
+            GwentServerService gwentServerService,
+            GwentDatabaseService databaseService)
+        {
+            _logger = logger;
+            _gwentServerService = gwentServerService;
+            _databaseService = databaseService;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var now = DateTime.UtcNow;
+                    
+                    // Check if it's the date of the season end
+                    if (now.Month == 6 && now.Day == 21 && now.Hour == 0 && now.Minute == 0)
+                    {
+                        Console.WriteLine("Executing monthly rank reset and seasonal rewards...");
+                        _logger.LogInformation("Executing monthly rank reset and seasonal rewards...");
+                        
+                        // First award seasonal rewards
+                        await AwardSeasonalRewards();
+                        
+                        // Then reset ranks
+                        await ResetPlayerRanks();
+                    }
+
+                    // Wait for 1 minute before next check
+                    await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error occurred while executing scheduled events");
+                    await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+                }
+            }
+        }
+
+        private async Task AwardSeasonalRewards()
+        {
+            try
+            {
+                // Get top players by MMR
+                var topPlayers = _databaseService.GetAllPlayers()
+                    .OrderByDescending(p => p.MMR)
+                    .ToList();
+
+                // Award rewards to top players
+                for (int i = 0; i < topPlayers.Count; i++)
+                {
+                    var player = topPlayers[i];
+                    var rank = i + 1;
+
+                    // Award borders
+                    if (rank <= 100)
+                    {
+                        await _gwentServerService.AddBorder(player.PlayerName, "Season1Border1");
+                    }
+                    if (rank <= 50)
+                    {
+                        await _gwentServerService.AddBorder(player.PlayerName, "Season1Border2");
+                    }
+                    if (rank <= 20)
+                    {
+                        await _gwentServerService.AddBorder(player.PlayerName, "Season1Border3");
+                    }
+                    if (rank <= 10)
+                    {
+                        await _gwentServerService.AddBorder(player.PlayerName, "Season1Border4");
+                    }
+                    if (rank <= 5)
+                    {
+                        await _gwentServerService.AddBorder(player.PlayerName, "Season1Border5");
+                    }
+                    if (rank == 1)
+                    {
+                        await _gwentServerService.AddBorder(player.PlayerName, "Season1Border6");
+                    }
+
+                    // Award titles
+                    if (rank <= 100)
+                    {
+                        await _gwentServerService.AddTitle(player.PlayerName, "MAN-AT-ARMS");
+                    }
+                    if (rank <= 50)
+                    {
+                        await _gwentServerService.AddTitle(player.PlayerName, "MERCENARY");
+                    }
+                    if (rank <= 20)
+                    {
+                        await _gwentServerService.AddTitle(player.PlayerName, "BOUNTYHUNTER");
+                    }
+                    if (rank <= 10)
+                    {
+                        await _gwentServerService.AddTitle(player.PlayerName, "VETERAN");
+                    }
+                    if (rank <= 5)
+                    {
+                        await _gwentServerService.AddTitle(player.PlayerName, "CHAMPION");
+                    }
+                    if (rank == 1)
+                    {
+                        await _gwentServerService.AddTitle(player.PlayerName, "HERO");
+                    }
+
+                    // Award avatar to top 10
+                    if (rank <= 10)
+                    {
+                        await _gwentServerService.AddAvatar(player.PlayerName, "Imlerith_Unmasked");
+                    }
+                }
+                
+                _logger.LogInformation("Successfully awarded seasonal rewards");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while awarding seasonal rewards");
+                throw;
+            }
+        }
+
+        private async Task ResetPlayerRanks()
+        {
+            try
+            {
+                // Get all players and reset their MMR to the starting value
+                var players = _databaseService.GetAllPlayers();
+                foreach (var player in players)
+                {
+                    await _databaseService.ResetPlayerMMR(player.UserName, _databaseService.initMMR);
+                }
+                
+                _logger.LogInformation("Successfully reset ranks for all players");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while resetting player ranks");
+                throw;
+            }
+        }
+    }
+} 

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/ScheduledEventService.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/ScheduledEventService.cs
@@ -44,12 +44,12 @@ namespace Cynthia.Card.Server
                     }
 
                     // Wait for 1 minute before next check
-                    await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+                    await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Error occurred while executing scheduled events");
-                    await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+                    await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
                 }
             }
         }

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/ScheduledEventService.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/ScheduledEventService.cs
@@ -31,7 +31,7 @@ namespace Cynthia.Card.Server
                     var now = DateTime.UtcNow;
                     
                     // Check if it's the date of the season end
-                    if (now.Month == 6 && now.Day == 21 && now.Hour == 0 && now.Minute == 0)
+                    if (now.Month == 6 && now.Day == 23 && now.Hour == 0 && now.Minute == 0)
                     {
                         Console.WriteLine("Executing monthly rank reset and seasonal rewards...");
                         _logger.LogInformation("Executing monthly rank reset and seasonal rewards...");

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Startup.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Startup.cs
@@ -32,6 +32,8 @@ namespace Cynthia.Card.Server
             services.AddSingleton<GwentLocalizationService>();
             services.AddSingleton<CounterService>();
             services.AddSingleton<Random>(x => new Random((int)DateTime.UtcNow.Ticks));
+            // Add the scheduled event service
+            services.AddHostedService<ScheduledEventService>();
             services.AddAntDesign();
             services.AddBlazoredLocalStorage();
             services.AddTransient<IMongoClient, MongoClient>(x => new MongoClient(GetConnectionString()));


### PR DESCRIPTION
Automates season end: adds a service to schedule events. On a specified date, first end season rewards are awarded, then ranks get reset to 3400.

Current season end is set to  23/06 at UTC 00:00