### PR TITLE
NoonWraith fix

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/NightWraith.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/NightWraith.cs
@@ -8,39 +8,28 @@ namespace Cynthia.Card
     {//On turn end, Boost all Mirror Image copies on both sides of the row by 1 and transform self into a Noonwraith.
         //在回合结束时，提升所在排双方所有“镜像”1点增益，并变形为“老鼠”。
         public NightWraith(GameCard card) : base(card) { }
+        private int mystrength = 8;
+        private int myhealth = 0;
         public async Task HandleEvent(AfterTurnOver @event)
         {
             if (@event.PlayerIndex == Card.PlayerIndex && Card.Status.CardRow.IsOnPlace())
             {
+                mystrength = Card.Status.Strength;
+                myhealth = Card.Status.HealthStatus;
                 //Boost all Mirror Image copies on both sides of the row by 1
                 var cards = Game.RowToList(AnotherPlayer, Card.Status.CardRow).IgnoreConcealAndDead().Concat(Game.RowToList(PlayerIndex, Card.Status.CardRow).IgnoreConcealAndDead()).Where(x => x.Status.CardRow.IsOnPlace() && x.Status.CardId == CardId.MirrorImage);
                 foreach (var card in cards)
                 {
                     await card.Effect.Boost(1, Card);
                 }
-                
-                int Power=Card.CardPoint();
-                int Strength = Card.Status.Strength;
-                int Change = Power - Strength;
                 //transform self into a Noonwraith.
-                
-                await Card.Effect.Transform(CardId.NoonWraith, Card, x => x.Status.Strength = Strength, isForce: true);
-
-                if (Change>0)
+                await Card.Effect.Transform(CardId.NoonWraith, Card, x =>
                 {
-                    await Boost_Quiet(Change, Card);
-                }
-                if (Change<0)
-                {
-                    await Lower_Power_By(-Change, Card);
-                }
-
+                    x.Status.Strength = mystrength;
+                    x.Status.HealthStatus = myhealth;
+                });
                 return;
-
-                
             }
-
-            
         }
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/NoonWraith.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/NoonWraith.cs
@@ -7,6 +7,8 @@ namespace Cynthia.Card
     {//Deploy: Spawn a Mirror Image on both sides of the row. On turn end, repeat deploy ability and transform into a Nightwraith.
         //部署：在所在排的双方生成一个“镜像”。在回合结束
         public NoonWraith(GameCard card) : base(card) { }
+        private int mystrength = 8;
+        private int myhealth = 0;
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
             //Spawn a Mirror Image on both sides of the row.
@@ -27,15 +29,11 @@ namespace Cynthia.Card
                 int Change = Power - Strength;
                 //and transform into a Nightwraith.
 
-                await Card.Effect.Transform(CardId.NightWraith, Card, x => x.Status.Strength = Strength, isForce: true);
-                if (Change>0)
+                await Card.Effect.Transform(CardId.NightWraith, Card, x =>
                 {
-                    await Boost_Quiet(Change, Card);
-                }
-                if (Change<0)
-                {
-                    await Lower_Power_By(-Change, Card);
-                }
+                    x.Status.Strength = mystrength;
+                    x.Status.HealthStatus = myhealth;
+                });
                 return;
 
             }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/NoonWraith.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/DIY/Monsters/Copper/NoonWraith.cs
@@ -21,6 +21,8 @@ namespace Cynthia.Card
         {//On turn end, repeat deploy ability and transform into a Nightwraith.
             if (@event.PlayerIndex == Card.PlayerIndex && Card.Status.CardRow.IsOnPlace())
             {
+                mystrength = Card.Status.Strength;
+                myhealth = Card.Status.HealthStatus;
                 //On turn end, repeat deploy ability
                 await Game.CreateCardAtEnd(CardId.MirrorImage, PlayerIndex, Card.Status.CardRow);
                 await Game.CreateCardAtEnd(CardId.MirrorImage, AnotherPlayer, Card.Status.CardRow);


### PR DESCRIPTION
Fixed Night and Noon Wraiths to keep same strength and health status through transformations without using the new "quietboost" and "lowerpower" methods.

I realize I come late to the party, but here is my solution, maybe those new methods aren't needed.