### PR TITLE
round time changes

### DIFF
--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Code/GameCodeService.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Code/GameCodeService.cs
@@ -225,7 +225,7 @@ namespace Cynthia.Card.Client
         public void GameStart()
         {
             // start timing for deciding red coin
-            _code.GetComponent<GameCode>().GameUIControl.ropeController.StartRopeTimer(45f);
+            _code.GetComponent<GameCode>().GameUIControl.ropeController.StartRopeTimer();
             _code.GetComponent<GameCode>().GameUIControl.SetDecideCoinInfo(true);
         }
         /*

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Code/GameCodeService.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Code/GameCodeService.cs
@@ -225,7 +225,7 @@ namespace Cynthia.Card.Client
         public void GameStart()
         {
             // start timing for deciding red coin
-            _code.GetComponent<GameCode>().GameUIControl.ropeController.StartRopeTimer();
+            _code.GetComponent<GameCode>().GameUIControl.ropeController.StartRopeTimer(45f);
             _code.GetComponent<GameCode>().GameUIControl.SetDecideCoinInfo(true);
         }
         /*

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Code/GwentClientService.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Code/GwentClientService.cs
@@ -385,7 +385,7 @@ namespace Cynthia.Card.Client
         public async Task<UserInfo> Login(string username, string password)
         {
             //登录,如果成功保存登录信息
-            User = await HubConnection.InvokeAsync<UserInfo>("Login", username, password);
+            User = await HubConnection.InvokeAsync<UserInfo>("LoginAccount", username, password);
             if (User != null)
                 Player.PlayerName = User.PlayerName;
             return User;

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/BGMs/BGMManager.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/BGMs/BGMManager.cs
@@ -68,6 +68,7 @@ public class BGMManager : MonoBehaviour
     public Sound[] soundList;
 
     public static BGMManager instance;
+    public static bool loggedSuccesfully = false;
     public AudioMixer audioMixer;
     public AudioMixerGroup groupMusic;
     public float bgmChangeSpeed = 0.01f;
@@ -258,7 +259,7 @@ public class BGMManager : MonoBehaviour
         if (inGame == false)
         {
             scene = SceneManager.GetActiveScene();
-            if (scene.name == "LoginScene")
+            if(loggedSuccesfully)
             {
                 PlaySound("Title");
                 inGame = true;

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameUIInfo/RopeController.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/GamePlay/GameUIInfo/RopeController.cs
@@ -16,7 +16,7 @@ public class RopeController : MonoBehaviour
     private float endWaitTime = 0.5f;
     private int shakeRange = 1;
     public bool isRunning = false;
-    public float remainingTime = 90f;
+    public float remainingTime = 60f;
     public int skipedTurns=0;
     private int count = 0; // count for fixed update to record if it's the first time it is called during a turn
     private int oldCount = 0;
@@ -24,7 +24,7 @@ public class RopeController : MonoBehaviour
     {
         await DependencyResolver.Container.Resolve<GwentClientService>().Surrender();
     }
-    public void StartRopeTimer(float totalTime = 90f)
+    public void StartRopeTimer(float totalTime = 60f)
     {
         rope.gameObject.SetActive(false); // is not active until ropeTime
         remainingTime = totalTime;

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/LoginScript/GameInit.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/LoginScript/GameInit.cs
@@ -24,7 +24,7 @@ public class GameInit : MonoBehaviour
     public Text VersionText;
     public RectTransform NotesContext;
     private string UpToDateVersion;
-    private string CurrentVersion="2.1.8";
+    private string CurrentVersion="2.1.9";
     public GameObject Download_Button;
     string link;
 

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/LoginScript/LoginClick.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/LoginScript/LoginClick.cs
@@ -74,6 +74,7 @@ public class LoginClick : MonoBehaviour
             }
             //Debug.Log($"用户名是:{_client.User.UserName},密码是:{_client.User.PassWord}");
             LogMessage.text = string.Format(_translator.GetText("LoginMenu_WelcomeMessage"), _client.User.PlayerName);
+            BGMManager.loggedSuccesfully = true;
 
             //SceneManager.LoadScene("Game");
 
@@ -82,7 +83,6 @@ public class LoginClick : MonoBehaviour
                 _client.ClientState = ClientState.Standby;
                 // Debug.Log("执行了!跳转后");
                 IsLogining = false;
-                BGMManager.loggedSuccesfully = true;
             };
 
             

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/LoginScript/LoginClick.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/LoginScript/LoginClick.cs
@@ -82,6 +82,7 @@ public class LoginClick : MonoBehaviour
                 _client.ClientState = ClientState.Standby;
                 // Debug.Log("执行了!跳转后");
                 IsLogining = false;
+                BGMManager.loggedSuccesfully = true;
             };
 
             

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/RankListMenu/PlayerTableRowScript.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/RankListMenu/PlayerTableRowScript.cs
@@ -110,7 +110,7 @@ public class PlayerTableRowScript : MonoBehaviour
 
         if (LoggedPlayerLineBackground != null && LoggedPlayerLine != null)
         {
-            if (rank <= 3)
+            if (rank == 1)
             {
                 LoggedPlayerLine.color = PlayerTableRowScript.topLineColor;
                 LoggedPlayerLineBackground.color = PlayerTableRowScript.topBackgroundColor;

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/RankListMenu/RankPlayerScreenScript.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/RankListMenu/RankPlayerScreenScript.cs
@@ -332,7 +332,7 @@ public class RankPlayerScreenScript : MonoBehaviour
             Color tintColor = new Color(1f, 0.455f, 0.027f, 1.0f);
             if (factionsRanks[buttonid][_factionRankPosition - 1].Item1 == _clientService.User.PlayerName)
             {
-                tintColor = new Color(0.976f, 1.0f, 0.027f, 1.0f);
+                tintColor = new Color(0.993f, 0.785f, 0.135f, 1.0f);
             }
             players.transform.GetChild(11).GetChild(1).GetComponent<Text>().color = tintColor;
             players.transform.GetChild(11).GetChild(2).GetComponent<Text>().color = tintColor;

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/TrinketsMenu/TrinketsInfo.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/TrinketsMenu/TrinketsInfo.cs
@@ -130,7 +130,7 @@ public class TrinketsInfo : MonoBehaviour // this script controls the behaviour 
 
     public void SetTitlesInfo(IList<Title> Titles)
     {   // Controls the layout of the titles in the titles menu
-        var pagenum = 30;
+        var pagenum = Titles.Count;
         TitlesScroll.value = 1;
         RemoveAllChild(TitlesContext);
         var sc = 0;

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/TrinketsMenu/TrinketsShow.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/TrinketsMenu/TrinketsShow.cs
@@ -103,13 +103,18 @@ public class TrinketsShow : MonoBehaviour // this script controls the avatar tri
     }
     public void SetTitleList (string title, string color) // set the look of the title in the title list
     {
-        if (!_clientService.User.OwnedTitles.Contains(title))
-        {
-            TitlesBackground.material = LightGray;
-        }
         TitleText.text = _translator.GetText(title+"Name");
         TitleText.color = mycolormap[color];
         trinketID = title;
         titleColor = mycolormap[color];
-    }
+        TitleText.fontStyle = FontStyle.Normal;
+
+        if (!_clientService.User.OwnedTitles.Contains(title))
+        {
+            TitlesBackground.material = LightGray;
+            TitleText.color = Color.Lerp(TitleText.color, Color.gray, 0.83f);
+            titleColor = Color.Lerp(titleColor, Color.gray, 0.83f);
+            TitleText.fontStyle = FontStyle.Italic;
+            TitleText.resizeTextMaxSize -= 9;
+        }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/TrinketMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/TrinketMap.cs
@@ -1171,6 +1171,51 @@ namespace Cynthia.Card
                 }
             },
             {
+                "MONSTER",
+                new Title()
+                {
+                    ID = "MONSTER",
+                    IsReleased = true,
+                    TitleColor = "red",
+                }
+            },
+            {
+                "NILFGAARDIAN",
+                new Title()
+                {
+                    ID = "NILFGAARDIAN",
+                    IsReleased = true,
+                    TitleColor = "lightgray",
+                }
+            },
+            {
+                "NORTHERNER",
+                new Title()
+                {
+                    ID = "NORTHERNER",
+                    IsReleased = true,
+                    TitleColor = "nrblue",
+                }
+            },
+            {
+                "SCOIA'TAEL",
+                new Title()
+                {
+                    ID = "SCOIA'TAEL",
+                    IsReleased = true,
+                    TitleColor = "lightgreen",
+                }
+            },
+            { 
+                "SKELLIGER",
+                new Title()
+                {
+                    ID = "SKELLIGER",
+                    IsReleased = true,
+                    TitleColor = "purple",
+                }
+            },
+            {
                 "DRAGONHATCHLING",
                 new Title()
                 {
@@ -1222,51 +1267,6 @@ namespace Cynthia.Card
                     ID = "GOLDENDRAGON",
                     IsReleased = true,
                     TitleColor = "orange",
-                }
-            },
-            {
-                "MONSTER",
-                new Title()
-                {
-                    ID = "MONSTER",
-                    IsReleased = true,
-                    TitleColor = "red",
-                }
-            },
-            {
-                "NILFGAARDIAN",
-                new Title()
-                {
-                    ID = "NILFGAARDIAN",
-                    IsReleased = true,
-                    TitleColor = "lightgray",
-                }
-            },
-            {
-                "NORTHERNER",
-                new Title()
-                {
-                    ID = "NORTHERNER",
-                    IsReleased = true,
-                    TitleColor = "nrblue",
-                }
-            },
-            {
-                "SCOIA'TAEL",
-                new Title()
-                {
-                    ID = "SCOIA'TAEL",
-                    IsReleased = true,
-                    TitleColor = "lightgreen",
-                }
-            },
-            { 
-                "SKELLIGER",
-                new Title()
-                {
-                    ID = "SKELLIGER",
-                    IsReleased = true,
-                    TitleColor = "purple",
                 }
             },
             {

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Hubs/GwentHub.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Hubs/GwentHub.cs
@@ -17,7 +17,7 @@ namespace Cynthia.Card.Server
         public bool Register(string username, string password, string playername) => _gwentServerService.Register(username, password, playername);
 
         //登录
-        public async Task<UserInfo> Login(string username, string password) => await _gwentServerService.Login(new User(username, Context.ConnectionId), password);
+        public async Task<UserInfo> LoginAccount(string username, string password) => await _gwentServerService.LoginAccount(new User(username, Context.ConnectionId), password);
         // update the userinfo when loading GameScene to update the avatars/borders/titles
         public async Task<UserInfo> QueryUserInfo(string username, string password) => await _gwentServerService.QueryUserInfo(username, password);
         

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentServerService.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentServerService.cs
@@ -730,7 +730,7 @@ namespace Cynthia.Card.Server
         public async Task<string> GetLatestVersion(string connectionId)
         {
             await Task.CompletedTask;
-            return "2.1.8";
+            return "2.1.9";
         }
 
         public async Task<string> GetNotes(string connectionId)
@@ -985,7 +985,7 @@ When other players are available, player matchmaking will be prioritized. Add #f
         public async Task<string> GetLatestClientVersion(string connectionId)
         {
             await Task.CompletedTask;
-            return @"2.1.8";
+            return @"2.1.9";
         }
         //-------------------------------------------------------------------------
         public int GetUserCount()

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentServerService.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentServerService.cs
@@ -740,6 +740,7 @@ namespace Cynthia.Card.Server
 本作永久免费开源,欢迎加群闲聊约战~关注第一消息
 群号: 949112936/945408322
 查看实时在线人数: http://cynthia.ovyno.com:5005
+~ Versions older than 2.1.9 are no longer valid, please update the client.
 
 To dowload the latest version of the game and interact with the community, please visit our Discord at https://discord.gg/Dw9sKgaUZN
 
@@ -957,6 +958,7 @@ may come back in the future.
         {
             await Task.CompletedTask;
             return @"This is the DIY server, have fun playing!
+~ Versions older than 2.1.9 are no longer valid, please update the client.
 
 This game is permanently free and open-source.
 To download the latest version of the game and interact with the community, please visit our Discord: https://discord.gg/Dw9sKgaUZN

--- a/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentServerService.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Server/Services/GwentGameService/GwentServerService.cs
@@ -357,7 +357,7 @@ namespace Cynthia.Card.Server
             return loginUser;
         }
 
-        public async Task<UserInfo> Login(User user, string password)
+        public async Task<UserInfo> LoginAccount(User user, string password)
         {
             //判断用户名与密码
             var loginUser = _databaseService.Login(user.UserName, password);


### PR DESCRIPTION
Proposition to modify the turn time change to 60s like in the original and token selection to 45s. This may prevent from certain players roping each round, waiting few minutes when enemy starts on afk, make waiting in queue shorter.. prevent logging to the game with all old clients with big rope time (90s+)