### PR TITLE
Fixes around the coin

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.AI/Core/RandomAutoAIPlayer.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.AI/Core/RandomAutoAIPlayer.cs
@@ -35,7 +35,7 @@ namespace Cynthia.Card.AI
             {
                 var result = new List<int>()
                     {
-                        info.SelectList.Indexed().First(x=>x.Value.Name=="0").Key
+                        info.SelectList.Indexed().First(x=>x.Value.Name=="1").Key
                     };
                 send(
                     Operation.Create(UserOperationType.SelectMenuCardsInfo,

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Gold/BloodyBaron.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Gold/BloodyBaron.cs
@@ -11,7 +11,7 @@ namespace Cynthia.Card
         public async Task HandleEvent(BeforeCardToCemetery @event)
         {
             if (!@event.isRoundEnd && @event.Target.PlayerIndex != Card.PlayerIndex && @event.Target.Status.Type == CardType.Unit
-                && (Card.Status.CardRow.IsOnPlace() || Card.Status.CardRow.IsInDeck() || Card.Status.CardRow.IsInHand()) && @event.DeathLocation.RowPosition.IsOnPlace())
+                && (Card.Status.CardRow.IsOnPlace() || Card.Status.CardRow.IsInDeck() || Card.Status.CardRow.IsInHand()) && @event.DeathLocation.RowPosition.IsOnPlace() && @event.Target.CardInfo().CardId != "70014")
             {
                 await Card.Effect.Boost(1, Card);
             }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Silver/DraigBonDhu.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Silver/DraigBonDhu.cs
@@ -13,7 +13,7 @@ namespace Cynthia.Card
         {
             //以下代码基于此卡可以选择双方墓地
             //显示我方墓地单位卡(顺序)
-            var list = Game.PlayersCemetery[Card.PlayerIndex].Where(x => x.CardInfo().CardType == CardType.Unit).ToList();
+            var list = Game.PlayersCemetery[Card.PlayerIndex].Where(x => x.CardInfo().CardType == CardType.Unit && x.CardInfo().CardId != "70014").ToList();
 
             //选择两张牌，如果不选，什么都不做
             var result = await Game.GetSelectMenuCards(Card.PlayerIndex, list, 2, "选择强化两张牌");


### PR DESCRIPTION
-Fixes Draig to not include Coin in list to boost
-Fixes Baron to not count coin entering graveyard as enemy dying
-Makes all AIs bet 1. Mostly intended to let players consistently test scenarios where they go first without 50/50 at the start and easier testing of mechanics including coin (as the ones I mentioned above). I dont think that break anything but let me know if you can think of smth