### PR TITLE
prevents double rightclick on mobile

### DIFF
--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Editor.meta
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e294503037d7da84cb6ed1421328d8a1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Editor/BuildVersionWriter.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Editor/BuildVersionWriter.cs
@@ -13,7 +13,7 @@ public class BuildVersionWriter : IPostprocessBuildWithReport
     {
         string outputDir = Path.GetDirectoryName(report.summary.outputPath);
         string versionFile = Path.Combine(outputDir, "version.txt");
-        File.WriteAllText(versionFile, Application.version);
+        File.WriteAllText(versionFile, PlayerSettings.bundleVersion);
         Debug.Log("BuildVersionWriter: version.txt written -> " + Application.version);
     }
 }

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Editor/BuildVersionWriter.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Editor/BuildVersionWriter.cs
@@ -13,7 +13,7 @@ public class BuildVersionWriter : IPostprocessBuildWithReport
     {
         string outputDir = Path.GetDirectoryName(report.summary.outputPath);
         string versionFile = Path.Combine(outputDir, "version.txt");
-        File.WriteAllText(versionFile, PlayerSettings.bundleVersion);
+        File.WriteAllText(versionFile, "2.1.9");
         Debug.Log("BuildVersionWriter: version.txt written -> " + Application.version);
     }
 }

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Editor/BuildVersionWriter.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Editor/BuildVersionWriter.cs
@@ -1,0 +1,19 @@
+// Assets/Editor/BuildVersionWriter.cs
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using System.IO;
+
+public class BuildVersionWriter : IPostprocessBuildWithReport
+{
+    public int callbackOrder => 0;
+
+    public void OnPostprocessBuild(BuildReport report)
+    {
+        string outputDir = Path.GetDirectoryName(report.summary.outputPath);
+        string versionFile = Path.Combine(outputDir, "version.txt");
+        File.WriteAllText(versionFile, Application.version);
+        Debug.Log("BuildVersionWriter: version.txt written -> " + Application.version);
+    }
+}

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Editor/BuildVersionWriter.cs.meta
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Editor/BuildVersionWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 344cbe580f967804a8691afbe83afd6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/EditorMenu/EditorInfo.cs
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/Assets/Script/EditorMenu/EditorInfo.cs
@@ -505,14 +505,16 @@ public class EditorInfo : MonoBehaviour
 #endif
         if (Input.GetMouseButtonDown(1) || IsRightClickMobile)
         {
+            IsRightClickMobile = false;
+            pressTime = 0;              
+
             if (EditorArtCard.gameObject.activeSelf || ShowArtCard.gameObject.activeSelf)
             {
                 RightClickedCardID = LastHoveredCard;
-                Debug.Log("Right Clicked ID: "+RightClickedCardID);
-                //RighClickActive=true;
+                Debug.Log("Right Clicked ID: " + RightClickedCardID);
                 SceneManager.LoadScene("RightClick", LoadSceneMode.Additive);
             }
-        }        
+        }
     }
             
     public void ClickSwitchUICard(CardStatus card)

--- a/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/ProjectSettings/ProjectSettings.asset
+++ b/src/Cynthia.Card.Unity/src/Cynthia.Unity.Card/ProjectSettings/ProjectSettings.asset
@@ -123,7 +123,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.1.0.5
+  bundleVersion: 2.1.9
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
simple bugfix preventing double rightclick on mobile
also version bump for unity (for launcher purposes) and script to put txt with version next to a client
