### PR TITLE
Fix the problems caused by CursedScroll deletion

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/CardId.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/CardId.cs
@@ -667,5 +667,7 @@ namespace Cynthia.Card
         public const string MirrorImage = "70186";
         public const string NightWraith = "70187";
         public const string Bronibor = "70188";
+        public const string ArcaneTome = "70189";
+
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -8,7 +8,7 @@ namespace Cynthia.Card
     public static class GwentMap
     {
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 148);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 149);
         public static IDictionary<string, int> CardIdMap { get; set; }
         public static string[] CardIdIndexMap { get; set; }
 
@@ -15173,6 +15173,27 @@ namespace Cynthia.Card
                     Info = "生成并打出一个“可怜的步兵”，然后使我方半场上每个士兵单位对随机敌方单位造成一点伤害",
                     CardArtsId = "c10003900",
                     LinkedCards=new List<String> {"44020"},
+                }
+            },
+            {
+                "70189",//奥术法典 Arcane Tome
+                new GwentCard()
+                {
+                    CardId ="70189", //Arcane Tome
+                    Name="奥术法典",
+                    Strength=0,
+                    Group=Group.Copper,
+                    Faction = Faction.NorthernRealms,
+                    CardUseInfo = CardUseInfo.AnyPlace,
+                    CardType = CardType.Special,
+                    IsDoomed = false,
+                    IsCountdown = false,
+                    IsDerive = true,
+                    Categories = new Categorie[]{Categorie.Special, Categorie.Item},
+                    Flavor = "阿尔祖的宏篇巨著，写满了这位传奇法师的毕生所学。",
+                    Info = "对一个单位造成3点伤害。如果该单位被摧毁，则生成并打出一个“凯文尼亡灵”。",
+                    CardArtsId = "203103",
+                    LinkedCards=new List<String> {"44024"},
                 }
             },
         };


### PR DESCRIPTION
@fraloow it is as I feared, removing cursed scroll entirely from the game has caused many problems.

I fixed it by putting back Cursed Scroll in CardID and GwentMap, but setting isderive = true, this should make the card inaccessible in the game.